### PR TITLE
Handle redirected instances

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -316,7 +316,7 @@ function displayAccounts() {
         if (displayButtons) {
           user_handles.map((user_handle) => {
             $li.append(
-              followButton(user_handle, user_handle.split("@")[2], target_url)
+              followButton(user_handle, domains[user_handle.split("@")[2]].local_domain, target_url)
             );
           });
         }


### PR DESCRIPTION
Attempt to lookup the instance name from the domains table rather than assuming the domain part of the handle matches the instance domain name.

Fixes: #86 (hopefully, code is untested)