### PR TITLE
Check for proper ending of unwanted domains

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -850,7 +850,7 @@ function findHandles(text) {
 
   // remove common false positives
   let unwanted_domains =
-    /gmail\.com|mixcloud|linktr\.ee|pinboardxing\com|researchgate|about|bit\.ly|imprint|impressum|patreon|donate|blog|facebook|news|github|instagram|t\.me|medium\.com|t\.co|tiktok\.com|youtube\.com|pronouns\.page|mail@|observablehq|twitter\.com|contact@|kontakt@|protonmail|medium\.com|traewelling\.de|press@|support@|info@|pobox|hey\.com/;
+    /gmail\.com(?:$|\/)|mixcloud|linktr\.ee(?:$|\/)|pinboardxing\.com(?:$|\/)|researchgate|about|bit\.ly(?:$|\/)|imprint|impressum|patreon|donate|blog|facebook|news|github|instagram|t\.me(?:$|\/)|medium\.com(?:$|\/)|t\.co(?:$|\/)|tiktok\.com(?:$|\/)|youtube\.com(?:$|\/)|pronouns\.page(?:$|\/)|mail@|observablehq|twitter\.com(?:$|\/)|contact@|kontakt@|protonmail|traewelling\.de(?:$|\/)|press@|support@|info@|pobox|hey\.com(?:$|\/)/;
   words = words.filter((word) => !unwanted_domains.test(word));
   words = words.filter((w) => w);
 


### PR DESCRIPTION
My domain is `sarunint.com`, which is caught by this regex (notice the `sarunin_t.co_m`).

This PR checks if domains are ending of words, or followed by a backslash.

Also, `medium.com` appears twice for some reason.