### PR TITLE
remove unused function user_to_text()

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -890,27 +890,6 @@ function tweet_to_text(tweet) {
   return text;
 }
 
-function user_to_text(user) {
-  // where handles could be: name, description, location, entities url urls expanded_url, entities description urls expanded_url
-  let text = `${user["name"]} ${user["description"]} ${user["location"]}`;
-  if ("entities" in user) {
-    if ("url" in user["entities"] && "urls" in user["entities"]["url"]) {
-      user["entities"]["url"]["urls"].map(
-        (url) => (text += ` ${url["expanded_url"]} `)
-      );
-    }
-    if (
-      "description" in user["entities"] &&
-      "urls" in user["entities"]["description"]
-    ) {
-      user["entities"]["description"]["urls"].map(
-        (url) => (text += ` ${url["expanded_url"]} `)
-      );
-    }
-  }
-  return text;
-}
-
 async function processAccount(type, user) {
   let followings, follower, list;
 


### PR DESCRIPTION
`user_to_text()` apparently isn't used anywhere. 

`processAccount()` just uses an inline implmentation:
https://github.com/lucahammer/fedifinder/blob/b66762bb3149e42e8d7990a65c3da07f26e08506/public/client.js#L937

would suggest removing it.