### PR TITLE
Allow Dashes in Usernames

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -64,14 +64,14 @@ function findHandles(text) {
 
   words.map((word) => {
     // @username@server.tld
-    if (/^@[a-zA-Z0-9_]+@.+\.[a-zA-Z]+$/.test(word)) handles.push(word);
+    if (/^@[a-zA-Z0-9_\-]+@.+\.[a-zA-Z]+$/.test(word)) handles.push(word);
     // some people don't include the initial @
-    else if (/^[a-zA-Z0-9_]+@.+\.[a-zA-Z|]+$/.test(word))
+    else if (/^[a-zA-Z0-9_\-]+@.+\.[a-zA-Z|]+$/.test(word))
       handles.push(`@${word}`);
     // server.tld/@username
     // friendica: sub.domain.tld/profile/name
     else if (
-      /^.+\.[a-zA-Z]+.*\/(@|web\/|profile\/|\/u\/|\/c\/)[a-zA-Z0-9_]+\/*$/.test(
+      /^.+\.[a-zA-Z]+.*\/(@|web\/|profile\/|\/u\/|\/c\/)[a-zA-Z0-9_\-]+\/*$/.test(
         word
       )
     )

--- a/server.js
+++ b/server.js
@@ -311,7 +311,7 @@ app.get("/api/check", async (req, res) => {
   domain = domain ? domain[0].toLowerCase() : "";
 
   let handle = req.query.handle
-    ? req.query.handle.match(/^@?[a-zA-Z0-9_]+@[a-zA-Z0-9\-\.]+\.[a-zA-Z]+$/)
+    ? req.query.handle.match(/^@?[a-zA-Z0-9_\-]+@[a-zA-Z0-9\-\.]+\.[a-zA-Z]+$/)
     : "";
   handle = handle ? handle[0].replace(/^@/, "").toLowerCase() : "";
 


### PR DESCRIPTION
Hi there! 👋🏼 

I have a user, `@aj-foster@mastodon.tech` (a Pleroma server), that isn't recognized currently. It's on my Twitter profile [here](https://twitter.com/austin_j_foster). Assuming this is because of the dash, this PR adds dashes as a valid character in the username portion.

I made the change in a few places, but there may be more (or fewer) that should be changed.

Thanks for all that you do!