### PR TITLE
Add Docker support and some fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:16-alpine3.15
+
+RUN apk add --no-cache python3 make gcc g++ libc-dev
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install
+
+VOLUME /app/.data
+EXPOSE 8080
+
+ENTRYPOINT ["node"]
+CMD ["server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  fedifinder:
+    build: .
+    ports:
+      - 127.0.0.1:8080:8080
+    volumes:
+      - ./data:/app/.data
+    env_file:
+      - .env

--- a/server.js
+++ b/server.js
@@ -780,7 +780,8 @@ function get_nodeinfo(nodeinfo_url) {
 
 function checkHttps(req, res, next) {
   // protocol check, if http, redirect to https
-  if (req.get("X-Forwarded-Proto").indexOf("https") != -1) {
+  const forwardedProto = req.get("X-Forwarded-Proto");
+  if (forwardedProto && forwardedProto.indexOf("https") != -1) {
     return next();
   } else {
     res.redirect("https://" + req.hostname + req.url);


### PR DESCRIPTION
This PR adds:

- `Dockerfile` for building a Docker image
- `docker-compose.yml` for Docker Compose (uses `Dockerfile`)
- `.gitignore` to prevent accidental commits of project related files (Node modules, data directory and environment configuration – could maybe also include the `public/cached` folder, but I'm not sure if this is required)
- `.dockerignore` to exclude `node_modules` for Docker image build (maybe could also add the same files from `.gitignore`)
- fix for createApp() where a Promise should be returned (otherwise causes race condition on initial start)
- fix for checkHttps() when there is no `X-Forwarded-Protocol` header set

Unfortunately, I could not properly test the whole application as I cannot register a Twitter Developer Project to access v2 endpoints and OAuth 2.0 without giving my phone number (which I don't plan to do).