### PR TITLE
fix: skip errors from api/check when processing domains

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -253,7 +253,18 @@ const app = Vue.createApp({
             `${this.lookup_server}/api/check?handle=${domain.handle}&domain=${domain.domain}`
           )
             .then((response) => response.json())
-            .then((data) => this.processCheckedDomain(data))
+            .then((data) => {
+              if (data.error) {
+                console.error(
+                  "got error processing domain to check",
+                  domain,
+                  data
+                );
+                return;
+              }
+
+              this.processCheckedDomain(data);
+            })
         );
       }
     },


### PR DESCRIPTION
Fixes #175.

The validation is done in the fetch handler which is nasty but it seems to be the earliest place invalid data can be caught in the pipeline. Logging is done in order to provide context on issues for folks like me.