### PR TITLE
Allow FQDNs in usernames

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -71,7 +71,7 @@ function findHandles(text) {
 
   words.map((word) => {
     // @username@server.tld
-    if (/^@[a-zA-Z0-9_\-]+@.+\.[a-zA-Z]+$/.test(word))
+    if (/^@[a-zA-Z0-9_\-\.]+@.+\.[a-zA-Z]+$/.test(word))
       handles.push(word.replace(":", " "));
     // some people don't include the initial @
     else if (/^[a-zA-Z0-9_\-]+@.+\.[a-zA-Z|]+$/.test(word.replace(":", " ")))


### PR DESCRIPTION
As noted in #198, we're seeing that folks using the
IndieWeb-to-Fediverse bridge https://fed.brid.gy/ as their Mastodon
Server aren't detected as valid profile URLs for Mastodon, resulting in:

> No handles were found on your profile

We can make sure to include the `.` as a valid character in a URL,
allowing us to extract `@{fqdn}@{fqdn}`.

Closes #198.
