### PR TITLE
strip trailing dots before validating word

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -70,6 +70,9 @@ function findHandles(text) {
   let handles = [];
 
   words.map((word) => {
+    // strip leading, trailing dots from word
+    word = word.replace(/^\.*|\.*$/g, '');
+
     // @username@server.tld
     if (/^@[a-zA-Z0-9_\-\.]+@.+\.[a-zA-Z]+$/.test(word))
       handles.push(word.replace(":", " "));


### PR DESCRIPTION
Fixes discovery for account https://twitter.com/matthew_d_green

Bio:

```
I teach cryptography at Johns Hopkins. Screeching voice of the minority. (Mastodon at matthew_d_green@ioc.exchange.)
```

`word` would end up being `matthew_d_green@ioc.exchange.` which does not
match further validation.
